### PR TITLE
Add Python3 Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 2',
                  'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3',
+                 'Programming Language :: Python :: 3.9',
                  'Topic :: Internet']
 )
 


### PR DESCRIPTION
Support Python3 - The code as is already works on python3 - the setup.py just needed updated for it to be built for it.  I tested this against Python 3.9.2 with awscli 1.19.48 and botocore 1.20.48.

Signed-off-by: Scott A. Williams <scottwilliams@ucsb.edu>